### PR TITLE
Use http for downloading GPG key, check GPG integrity via fingerprint

### DIFF
--- a/tasks/use-apt.yml
+++ b/tasks/use-apt.yml
@@ -14,7 +14,10 @@
     - apt-transport-https
 
 - name: add APT signing key for td-agent
-  apt_key: url=https://packages.treasuredata.com/GPG-KEY-td-agent state=present
+  apt_key:
+    url: http://packages.treasuredata.com/GPG-KEY-td-agent
+    id: BEE682289B2217F45AF4CC3F901F9177AB97ACBE
+    state: present
 
 - name: add td-agent repository
   apt_repository: repo='deb https://packages.treasuredata.com/2/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}/ {{ ansible_distribution_release|lower }} contrib' state=present


### PR DESCRIPTION
Fixes

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for packages.treasuredata.com:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine or you can install the `urllib3`, `pyopenssl`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible. The exception msg was: [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure."}
```