### PR TITLE
Fix apt & yum deprecation warnings

### DIFF
--- a/tasks/use-apt.yml
+++ b/tasks/use-apt.yml
@@ -8,10 +8,11 @@
 #
 
 - name: install apt-related binaries for Ansible to work
-  apt: name={{ item }}  state=present update_cache=yes
-  with_items:
-    - python-software-properties
-    - apt-transport-https
+  apt: 
+    update_cache=yes
+    name:
+      - python-software-properties
+      - apt-transport-https
 
 - name: add APT signing key for td-agent
   apt_key:
@@ -34,10 +35,11 @@
 
 
 - name: install libcurl and make for compiling plugins
-  apt: name={{ item }}  state=present update_cache=yes
-  with_items:
-    - libcurl4-gnutls-dev
-    - build-essential
+  apt:
+    update_cache=yes
+    name:
+      - libcurl4-gnutls-dev
+      - build-essential
   when: tdagent_plugins is defined or tdagent_plugins_versions is defined
 
 

--- a/tasks/use-yum.yml
+++ b/tasks/use-yum.yml
@@ -30,11 +30,11 @@
 
 
 - name: install gcc and libcurlXXX for compiling plugins
-  yum: name={{ item }} state=present
-  with_items:
-    - gcc
-    - libcurl
-    - libcurl-devel
+  yum: 
+    name:
+      - gcc
+      - libcurl
+      - libcurl-devel
   when: tdagent_plugins is defined or tdagent_plugins_versions is defined
 
 


### PR DESCRIPTION
You can now pass the list directly to the `name:` option.